### PR TITLE
Print to stderr while loading

### DIFF
--- a/Sources/Core/Logger/Logger.swift
+++ b/Sources/Core/Logger/Logger.swift
@@ -20,7 +20,7 @@ struct Logger {
   ///   - queue: A closure that is called when this logger logs a message
   init(
     logLevel: Logger.Level = .info,
-    printer: @escaping (String) -> Void = { print($0) },
+    printer: @escaping (String) -> Void = loggerPrint,
     queue: DispatchQueue = loggerQueue
   ) {
     self.logLevel = logLevel
@@ -113,3 +113,13 @@ private let loggerQueue = DispatchQueue(
   label: "com.buildkite.collector-swift.logger",
   qos: .background
 )
+
+// Default printer used by Logger
+private func loggerPrint(_ message: String) {
+  // While loading, print to stderr to avoid conflicting with `swift test --list-tests`
+  if TestCollector.shared == nil {
+    fputs("\(message)\n", stderr)
+  } else {
+    print(message)
+  }
+}

--- a/Sources/Core/TestCollector.swift
+++ b/Sources/Core/TestCollector.swift
@@ -14,10 +14,7 @@ public struct TestCollector {
     logger: Logger? = nil
   ) {
     guard environment.isAnalyticsEnabled else {
-      // To prevent error when loading collector during `--list-tests`
-      DispatchQueue.main.async {
-        logger?.info("TestCollector disabled. Test results will not be collected.")
-      }
+      logger?.info("TestCollector disabled. Test results will not be collected.")
       self.observer = nil
       return
     }
@@ -30,10 +27,7 @@ public struct TestCollector {
       let runEnvironment = environment.runEnvironment()
       uploader = .live(api: api, logger: logger, runEnvironment: runEnvironment)
     } else {
-      // To prevent error when loading collector during `--list-tests`
-      DispatchQueue.main.async {
-        logger?.info("TestCollector unable to locate API key. Test results will not be uploaded.")
-      }
+      logger?.info("TestCollector unable to locate API key. Test results will not be uploaded.")
       uploader = nil
     }
 
@@ -53,13 +47,15 @@ public struct TestCollector {
   ///
   /// Used by the root target to create a collector and add it to the test observation center.
   ///
-  /// - Note: It is important that this method does not print synchronously eg. inside the TestCollector.init. Printing to the console here
-  /// causes an error  when using `swift test --list-tests` and `--parallel` on Linux.
+  /// - Note: It is important that this method does not print to stdout eg. inside the TestCollector.init. Outputting to stdout causes
+  /// an error  when using `swift test --list-tests` and `--parallel` on Linux.
   public static func load() {
     guard self.shared == nil else { return }
     let environment = EnvironmentValues()
     let logger = Logger(logLevel: environment.isAnalyticsDebugEnabled ? .debug : .info)
-    self.shared = TestCollector(environment: environment, logger: logger)
+    let collector = TestCollector(environment: environment, logger: logger)
+    logger.waitForLogs() // Ensures logging is complete to avoid printing to stdout
+    self.shared = collector
     self.shared?.observer.map(XCTestObservationCenter.shared.addTestObserver)
   }
 


### PR DESCRIPTION
## 💬 Summary of Changes

Changed default logger to output to stderr while loading. 

## 🧾 Checklist

- [x] 🧐 Performed a self-review of the changes
- [x] 🏎 Ran Unit Tests and they all passed
- [x] 🏷 Labeled this PR appropriately 

## 📝 Items of Note

- `waitForLogs()` is needed otherwise the shared collector would be set before the default printer checks if it needs to print to stderr.
