### PR TITLE
Update package name

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 import PackageDescription
 
 let package = Package(
-  name: "test-collector-swift",
+  name: "BuildkiteTestCollector",
   platforms: [
     .macOS("10.15"),
     .iOS("13.0"),


### PR DESCRIPTION
## 💬 Summary of Changes

Changed package name

## 🧾 Checklist

- [x] 🧐 Performed a self-review of the changes
- [x] 🏷 Labeled this PR appropriately 


## 📝 Items of Note

SPM uses the repository name as the package name when adding a product to the target. The name in the Package manifest is no longer used. 
