### PR TITLE
Allow test collector in release builds

### DIFF
--- a/Examples/DemoLibrary/.swiftpm/xcode/xcshareddata/xcschemes/DemoLibrary.xcscheme
+++ b/Examples/DemoLibrary/.swiftpm/xcode/xcshareddata/xcschemes/DemoLibrary.xcscheme
@@ -23,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      buildConfiguration = "Debug"
+      buildConfiguration = "Release"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">

--- a/Examples/DemoLibrary/Package.swift
+++ b/Examples/DemoLibrary/Package.swift
@@ -4,6 +4,12 @@ import PackageDescription
 
 let package = Package(
   name: "DemoLibrary",
+  platforms: [
+    .macOS("10.15"),
+    .iOS("13.0"),
+    .tvOS("13.0"),
+    .watchOS("6.0")
+  ],
   products: [
     .library(name: "DemoLibrary", targets: ["DemoLibrary"])
   ],

--- a/Examples/DemoLibrary/Tests/DemoLibraryTests/DemoLibraryTests.swift
+++ b/Examples/DemoLibrary/Tests/DemoLibraryTests/DemoLibraryTests.swift
@@ -1,4 +1,4 @@
-@testable import DemoLibrary
+import DemoLibrary
 import XCTest
 
 final class DemoLibraryTests: XCTestCase {

--- a/Sources/BuildkiteTestCollector/Loader.swift
+++ b/Sources/BuildkiteTestCollector/Loader.swift
@@ -2,6 +2,7 @@ import Core
 
 /// This function is automatically called by the Loader module to ensure the test collector is loaded before running any tests
 @_cdecl("loadCollector")
+@usableFromInline
 func loadCollector() {
   Core.TestCollector.load()
 }


### PR DESCRIPTION
## 💬 Summary of Changes

<!-- Provide a high level description & summary of what your PR is going to change. -->

- Added `@usableFromInline` to `loadCollector()` so it is part of the ABI and not stripped in release builds
- Changed Demo library's build configuration to `Release`

## 🧾 Checklist

<!-- Actions you should have taken before opening this pull request. -->

- [x] 🧐 Performed a self-review of the changes
- [x] ✅ Added tests to cover changes
- [x] 🏎 Ran Unit Tests and they all passed
- [x] 🏷 Labeled this PR appropriately 


## 📝 Items of Note

Currently trying to build tests that use the collector in release mode results in `Undefined symbol: _loadCollector`. This PR ensures the symbol is always defined by adding it to the ABI using `@usableFromInline`. See [Attributes](https://docs.swift.org/swift-book/ReferenceManual/Attributes.html) for more info on `@usableFromInline`.
