### PR TITLE
Deprecate `TestCollector.annotate`

### DIFF
--- a/Sources/BuildkiteTestCollector/Internal/Deprecations.swift
+++ b/Sources/BuildkiteTestCollector/Internal/Deprecations.swift
@@ -1,0 +1,15 @@
+import Core
+
+// MARK: - Deprecated after 0.3.0
+
+extension TestCollector {
+  /// Annotates the current test.
+  ///
+  /// The provided content is added to the collected span data and will appear in the span timeline.
+  ///
+  /// - Parameter content: The content of this annotation
+  @available(*, deprecated, message: "'annotate' is no longer supported")
+  public static func annotate(_ content: @autoclosure () -> String) {
+    Core.TestCollector.shared?.annotate(content())
+  }
+}

--- a/Sources/BuildkiteTestCollector/TestCollector.swift
+++ b/Sources/BuildkiteTestCollector/TestCollector.swift
@@ -1,12 +1,5 @@
 import Core
 
 public enum TestCollector {
-  /// Annotates the current test.
-  ///
-  /// The provided content is added to the collected span data and will appear in the span timeline.
-  ///
-  /// - Parameter content: The content of this annotation
-  public static func annotate(_ content: @autoclosure () -> String) {
-    Core.TestCollector.shared?.annotate(content())
-  }
+  // TODO: Add public api
 }


### PR DESCRIPTION
## 💬 Summary of Changes

<!-- Provide a high level description & summary of what your PR is going to change. -->

- Deprecate `TestCollector.annotate`

## 🧾 Checklist

<!-- Actions you should have taken before opening this pull request. -->

- [x] 🧐 Performed a self-review of the changes
- [x] 🏷 Labeled this PR appropriately 


## 📝 Items of Note

- The test collector can only be imported into test targets which limits the usefulness of `TestCollector.annotate`. If this type of functionality is added in the future, it would probably be better to incorporate it with something like [OSSignposter](https://developer.apple.com/documentation/os/ossignposter)
- `public enum TestCollector {}` doesn't really do anything anymore. It will remain as a public interface though for future features. e.g. #36  
