### PR TITLE
Fix Task with handler and cancellation deprecation warning

### DIFF
--- a/Sources/Core/ApiClient/ApiSession.swift
+++ b/Sources/Core/ApiClient/ApiSession.swift
@@ -25,19 +25,19 @@ extension ApiSession {
       let cancel: () -> Void = { dataTask?.cancel() }
 
       return try await withTaskCancellationHandler(
-        handler: { cancel() },
         operation: {
-          try await withCheckedThrowingContinuation { continuation in
-            dataTask = session.dataTask(with: request) { data, response, error in
-              if let data = data, let response = response {
-                continuation.resume(returning: (data, response))
-              } else {
-                continuation.resume(throwing: error ?? URLError(.badServerResponse))
-              }
+            try await withCheckedThrowingContinuation { continuation in
+                dataTask = session.dataTask(with: request) { data, response, error in
+                    if let data = data, let response = response {
+                        continuation.resume(returning: (data, response))
+                    } else {
+                        continuation.resume(throwing: error ?? URLError(.badServerResponse))
+                    }
+                }
+                dataTask?.resume()
             }
-            dataTask?.resume()
-          }
-        }
+        },
+        onCancel: { cancel() }
       )
     }
   }


### PR DESCRIPTION
The method was deprecated and a renamed variant was introduced. This PR uses the new variant. 

Saw that the warning is being fixed on this [change](https://github.com/buildkite/test-collector-swift/pull/44/files#diff-72084e8d361f1ee96b286ead2be292f7065342b4bf2f69cb70dae3843c86ba94R40) but not sure how long that PR will take to land. 