### PR TITLE
Use static methods for test name helpers

### DIFF
--- a/Sources/Core/Models/XCTest/XCTestCase+Helpers.swift
+++ b/Sources/Core/Models/XCTest/XCTestCase+Helpers.swift
@@ -1,21 +1,23 @@
 import XCTest
 
 extension XCTestCase {
-  /// The name of the class containing the test.
-  var caseName: String { "\(type(of: self))" }
+  /// Returns the class name of the test.
+  static func className(of testCase: XCTestCase) -> String {
+    "\(type(of: testCase))"
+  }
 
-  /// The name of the test.
-  var testName: String {
+  /// Returns the name of the test.
+  static func testName(of testCase: XCTestCase) -> String {
     #if canImport(ObjectiveC)
     // [XCTestCase testName]
     return String(
-      self.name
+      testCase.name
         .split(separator: " ", maxSplits: 1).last!
-        .dropLast(self.name.last == "]" ? 1 : 0)
+        .dropLast(testCase.name.last == "]" ? 1 : 0)
     )
     #else
     // XCTestCase.testName
-    return String(self.name.split(separator: ".").last!)
+    return String(testCase.name.split(separator: ".").last!)
     #endif
   }
 }

--- a/Sources/Core/TestObserver.swift
+++ b/Sources/Core/TestObserver.swift
@@ -39,8 +39,8 @@ class TestObserver: NSObject, XCTestObservation {
     self.spanId = self.tracer.startSpan(section: "top")
     self.test = TestState(
       id: self.uuid(),
-      className: testCase.caseName,
-      testName: testCase.testName
+      className: XCTestCase.className(of: testCase),
+      testName: XCTestCase.testName(of: testCase)
     )
   }
 

--- a/Tests/CoreTests/XCTestHelpersTests.swift
+++ b/Tests/CoreTests/XCTestHelpersTests.swift
@@ -3,10 +3,10 @@ import XCTest
 
 class XCTestHelpersTests: XCTestCase {
   func testTestName() {
-    XCTAssertEqual("testTestName", self.testName)
+    XCTAssertEqual("testTestName", XCTestCase.testName(of: self))
   }
 
-  func testCaseName() {
-    XCTAssertEqual("XCTestHelpersTests", self.caseName)
+  func testClassName() {
+    XCTAssertEqual("XCTestHelpersTests", XCTestCase.className(of: self))
   }
 }


### PR DESCRIPTION
## 💬 Summary of Changes

- Resolves #47
- Made helpers static functions to avoid conflicting with instance members

## 🧾 Checklist

- [x] 🧐 Performed a self-review of the changes
- [x] 🏎 Ran Unit Tests and they all passed
- [x] 🏷 Labeled this PR appropriately 
