### PR TITLE
PIE-1511 Remove identifier from swift test collector payloads

### DIFF
--- a/Sources/Core/Models/Api/Trace.swift
+++ b/Sources/Core/Models/Api/Trace.swift
@@ -13,9 +13,6 @@ struct Trace: Equatable {
   /// In XCTest this is usually a method of an XCTestCase.
   var name: String?
 
-  /// The identifier of the test.
-  var identifier: String?
-
   /// The source location of the test.
   var location: String?
 
@@ -40,7 +37,6 @@ extension Trace: Encodable {
     case id
     case scope
     case name
-    case identifier
     case location
     case fileName = "file_name"
     case result
@@ -55,7 +51,6 @@ extension Trace {
     self.id = test.id.uuidString
     self.scope = test.className
     self.name = test.testName
-    self.identifier = "\(test.className).\(test.testName)"
     self.result = test.result.map(Trace.Result.init) ?? .failed
     self.failureReason = test.issues.first?.compactDescription
     self.failureExpanded = test.issues.map(Trace.FailureExpanded.init(issue:))

--- a/Tests/CoreTests/UploadClientTests.swift
+++ b/Tests/CoreTests/UploadClientTests.swift
@@ -9,14 +9,13 @@ final class UploadClientTests: XCTestCase {
   func testWaitSynchronouslyForUploads() throws {
     let uploadCompleted = self.expectation(description: "upload completed")
     let uploadClient = UploadClient.live(api: .fulfill(uploadCompleted, after: 0.5), runEnvironment: EnvironmentValues().runEnvironment())
-    let trace = Trace(id: "id", history: .init(section: "section"))
+    let trace = Trace(id: "id", identifier: "identifier", history: .init(section: "section"))
 
     uploadClient.upload(trace: trace)
     uploadClient.waitForUploads()
 
     self.wait(for: [uploadCompleted], timeout: 0)
   }
-
   func testWaitShouldTimeout() throws {
     let uploadCompleted = self.expectation(description: "upload completed")
     uploadCompleted.isInverted = true

--- a/Tests/CoreTests/UploadClientTests.swift
+++ b/Tests/CoreTests/UploadClientTests.swift
@@ -9,13 +9,14 @@ final class UploadClientTests: XCTestCase {
   func testWaitSynchronouslyForUploads() throws {
     let uploadCompleted = self.expectation(description: "upload completed")
     let uploadClient = UploadClient.live(api: .fulfill(uploadCompleted, after: 0.5), runEnvironment: EnvironmentValues().runEnvironment())
-    let trace = Trace(id: "id", identifier: "identifier", history: .init(section: "section"))
+    let trace = Trace(id: "id", history: .init(section: "section"))
 
     uploadClient.upload(trace: trace)
     uploadClient.waitForUploads()
 
     self.wait(for: [uploadCompleted], timeout: 0)
   }
+
   func testWaitShouldTimeout() throws {
     let uploadCompleted = self.expectation(description: "upload completed")
     uploadCompleted.isInverted = true


### PR DESCRIPTION
## 💬 Summary of Changes

We have removed identifier field from DB test table, and we no longer using it in TA.
This PR is for removing identifier from this collector so that they stop sending identifier to TA. [We'll not make a release for this PR](https://linear.app/buildkite/issue/PIE-1427#comment-9ea47561)

Ticket: https://linear.app/buildkite/issue/PIE-1511/remove-identifier-from-swift-test-collector-payloads
Parent ticket: https://linear.app/buildkite/issue/PIE-1427/remove-identifier-from-test-collector-payloads

I don't have swift development experience. I wasn't too sure how to test the changes so did this PR with TDD, hopefully it can verify the changes.
1st commit: create trace with `identifier` provided, all tests passed
2nd commit: Remove `identifier` from trace. We see unit test failed as expected. 
3rd commit: Remove `identifier` from the unit test. Test then passed. 

## 🧾 Checklist

<!-- Actions you should have taken before opening this pull request. -->

- [x] 🧐 Performed a self-review of the changes
- [x] ✅ Added tests to cover changes
- [x] 🏎 Ran Unit Tests and they all passed
- [x] 🏷 Labeled this PR appropriately 


## 📝 Items of Note

<!--
Document anything here that you think the reviewer(s) of this PR may need to know or anything of
specific interest.
-->
