### PR TITLE
Add custom run environment values and base URL

### DIFF
--- a/Sources/BuildkiteTestCollector/TestCollector.swift
+++ b/Sources/BuildkiteTestCollector/TestCollector.swift
@@ -1,5 +1,7 @@
 import Core
 
 public enum TestCollector {
-  // TODO: Add public api
+  public static var baseUrl: String {
+    Core.TestCollector.baseURL
+  }
 }

--- a/Sources/BuildkiteTestCollector/TestCollector.swift
+++ b/Sources/BuildkiteTestCollector/TestCollector.swift
@@ -1,7 +1,8 @@
 import Core
 
 public enum TestCollector {
-  public static var baseUrl: String {
+  /// The base URL for the Test Analytics API.
+  public static var baseURL: String {
     Core.TestCollector.baseURL
   }
 }

--- a/Sources/Core/ApiClient/ApiClient+Live.swift
+++ b/Sources/Core/ApiClient/ApiClient+Live.swift
@@ -7,7 +7,7 @@ import FoundationNetworking
 extension ApiClient {
   static func live(
     apiToken: String,
-    baseUrl: URL = URL(string: "https://analytics-api.buildkite.com/v1/")!,
+    baseUrl: URL,
     encoder: JSONEncoder = .init(),
     decoder: JSONDecoder = .init(),
     session: ApiSession = .urlSession(.shared)

--- a/Sources/Core/ApiClient/ApiClient+Live.swift
+++ b/Sources/Core/ApiClient/ApiClient+Live.swift
@@ -7,13 +7,13 @@ import FoundationNetworking
 extension ApiClient {
   static func live(
     apiToken: String,
-    baseUrl: URL,
+    baseURL: URL,
     encoder: JSONEncoder = .init(),
     decoder: JSONDecoder = .init(),
     session: ApiSession = .urlSession(.shared)
   ) -> ApiClient {
     func makeRequest(from route: ApiRoute) throws -> URLRequest {
-      var request = URLRequest(url: baseUrl)
+      var request = URLRequest(url: baseURL)
       request.setValue("Token token=\"\(apiToken)\"", forHTTPHeaderField: "Authorization")
 
       switch route {

--- a/Sources/Core/Logger/Logger.swift
+++ b/Sources/Core/Logger/Logger.swift
@@ -17,7 +17,7 @@ struct Logger {
   /// - Parameters:
   ///   - logLevel: The log level for this logger
   ///   - log: A closure that is called when this logger logs a message
-  ///   - queue: A dispatch queue for scheduling  asynchronous logging
+  ///   - queue: A dispatch queue for scheduling asynchronous logging
   init(
     logLevel: Logger.Level = .info,
     printer: @escaping (String) -> Void = loggerPrint,

--- a/Sources/Core/Models/Api/RunEnvironment.swift
+++ b/Sources/Core/Models/Api/RunEnvironment.swift
@@ -42,7 +42,7 @@ struct RunEnvironment: Equatable {
   var collector: String?
 
   /// A dictionary that contains custom values associated with the test run.
-  /// 
+  ///
   /// - Note: Used internally for testing experimental features. If an existing key
   /// is used, the custom environment value will take precedence.
   var customEnvironment: [String: AnyCodable]?

--- a/Sources/Core/Models/Api/RunEnvironment.swift
+++ b/Sources/Core/Models/Api/RunEnvironment.swift
@@ -23,16 +23,16 @@ struct RunEnvironment: Equatable {
   /// The job identifier.
   var jobId: String?
 
-  /// A message associated with the test run
+  /// A message associated with the test run.
   var message: String?
 
   /// A value indicating if the collector ran in debug mode.
   var debug: String?
 
-  /// A tag added to the start of the execution name
+  /// A tag added to the start of the execution name.
   var executionNamePrefix: String?
 
-  /// A tag added to the end of the execution name
+  /// A tag added to the end of the execution name.
   var executionNameSuffix: String?
 
   /// The version of the collector used.
@@ -40,22 +40,63 @@ struct RunEnvironment: Equatable {
 
   /// The name of the collector used.
   var collector: String?
+
+  /// A dictionary that contains custom values associated with the test run.
+  /// 
+  /// - Note: Used internally for testing experimental features. If an existing key
+  /// is used, the custom environment value will take precedence.
+  var customEnvironment: [String: AnyCodable]?
 }
 
 extension RunEnvironment: Encodable {
-  enum CodingKeys: String, CodingKey {
-    case ci = "CI"
-    case key
-    case url
-    case branch
-    case commitSha = "commit_sha"
-    case number
-    case jobId = "job_id"
-    case message
-    case debug
-    case executionNamePrefix = "execution_name_prefix"
-    case executionNameSuffix = "execution_name_suffix"
-    case version
-    case collector
+  struct CodingKey: Swift.CodingKey {
+    var stringValue: String
+    var intValue: Int? { Int(self.stringValue) }
+
+    init(_ stringValue: String) {
+      self.stringValue = stringValue
+    }
+
+    init(stringValue: String) {
+      self.stringValue = stringValue
+    }
+
+    init(intValue: Int) {
+      self.stringValue = String(intValue)
+    }
+
+    static var ci = Self("CI")
+    static var key = Self("key")
+    static var url = Self("url")
+    static var branch = Self("branch")
+    static var commitSha = Self("commit_sha")
+    static var number = Self("number")
+    static var jobId = Self("job_id")
+    static var message = Self("message")
+    static var debug = Self("debug")
+    static var executionNamePrefix = Self("execution_name_prefix")
+    static var executionNameSuffix = Self("execution_name_suffix")
+    static var version = Self("version")
+    static var collector = Self("collector")
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKey.self)
+    try container.encodeIfPresent(self.ci, forKey: .ci)
+    try container.encode(self.key, forKey: .key)
+    try container.encodeIfPresent(self.url, forKey: .url)
+    try container.encodeIfPresent(self.branch, forKey: .branch)
+    try container.encodeIfPresent(self.commitSha, forKey: .commitSha)
+    try container.encodeIfPresent(self.number, forKey: .number)
+    try container.encodeIfPresent(self.jobId, forKey: .jobId)
+    try container.encodeIfPresent(self.message, forKey: .message)
+    try container.encodeIfPresent(self.debug, forKey: .debug)
+    try container.encodeIfPresent(self.executionNamePrefix, forKey: .executionNamePrefix)
+    try container.encodeIfPresent(self.executionNameSuffix, forKey: .executionNameSuffix)
+    try container.encodeIfPresent(self.version, forKey: .version)
+    try container.encodeIfPresent(self.collector, forKey: .collector)
+    for (key, value) in self.customEnvironment ?? [:] {
+      try container.encode(value, forKey: CodingKey(key))
+    }
   }
 }

--- a/Sources/Core/Models/Environment/EnvironmentValues+RunEnvironments.swift
+++ b/Sources/Core/Models/Environment/EnvironmentValues+RunEnvironments.swift
@@ -8,7 +8,7 @@ extension EnvironmentValues {
       ?? self.xcodeCloud
       ?? self.generic(key: defaultKey)
 
-    return RunEnvironment(
+    let runEnvironment = RunEnvironment(
       ci: ciEnv?.ci,
       key: self.analyticsKey ?? ciEnv?.key ?? defaultKey,
       url: self.analyticsUrl ?? ciEnv?.url,
@@ -21,16 +21,19 @@ extension EnvironmentValues {
       executionNamePrefix: self.executionNamePrefix,
       executionNameSuffix: self.executionNameSuffix,
       version: TestCollector.version,
-      collector: TestCollector.name
+      collector: TestCollector.name,
+      customEnvironment: self.customEnvironment
     )
+
+    logger?.debug("\(runEnvironment)")
+    
+    return runEnvironment
   }
 
   private var buildkite: RunEnvironment? {
     guard let buildId = self.buildkiteBuildId else { return nil }
 
-    logger?.debug("Successfully found Buildkite RunEnvironment")
-
-    return RunEnvironment(
+    let runEnvironment = RunEnvironment(
       ci: "buildkite",
       key: buildId,
       url: self.buildkiteBuildUrl,
@@ -40,6 +43,10 @@ extension EnvironmentValues {
       jobId: self.buildkiteJobId,
       message: self.buildkiteMessage
     )
+
+    logger?.debug("Successfully found Buildkite RunEnvironment")
+
+    return runEnvironment
   }
 
   private var circleCi: RunEnvironment? {
@@ -48,9 +55,7 @@ extension EnvironmentValues {
       let workFlowId = self.circleWorkflowId
     else { return nil }
 
-    logger?.debug("Successfully found Circle CI RunEnvironment")
-
-    return RunEnvironment(
+    let runEnvironment = RunEnvironment(
       ci: "circleci",
       key: "\(workFlowId)-\(buildNumber)",
       url: self.circleBuildUrl,
@@ -59,6 +64,10 @@ extension EnvironmentValues {
       number: buildNumber,
       message: "Build #\(buildNumber) on branch \(self.circleBranch ?? "[Unknown branch]")"
     )
+
+    logger?.debug("Successfully found Circle CI RunEnvironment")
+
+    return runEnvironment
   }
 
   private func generic(key: String) -> RunEnvironment? {
@@ -81,15 +90,13 @@ extension EnvironmentValues {
       let startedBy = self.githubWorkflowStartedBy
     else { return nil }
 
-    logger?.debug("Successfully found Github RunEnvironment")
-
     var url: String?
     if let repository = self.gitHubRepository, let runId = self.gitHubRunId {
       url = "https://github.com/\(repository)/actions/runs/\(runId)"
     }
     let message = "Run #\(runNumber) attempt #\(runAttempt) of \(workflowName), started by \(startedBy)"
 
-    return RunEnvironment(
+    let runEnvironment = RunEnvironment(
       ci: "github_actions",
       key: "\(action)-\(runNumber)-\(runAttempt)",
       url: url,
@@ -98,6 +105,10 @@ extension EnvironmentValues {
       number: runNumber,
       message: message
     )
+
+    logger?.debug("Successfully found Github RunEnvironment")
+
+    return runEnvironment
   }
 
   private var xcodeCloud: RunEnvironment? {
@@ -108,11 +119,9 @@ extension EnvironmentValues {
       let workflowName = self.xcodeWorkflowName
     else { return nil }
 
-    logger?.debug("Successfully found Xcode Cloud RunEnvironment")
-
     let message = "Build #\(buildNumber) of workflow: \(workflowName)"
 
-    return RunEnvironment(
+    let runEnvironment = RunEnvironment(
       ci: "xcodeCloud",
       key: buildID,
       url: self.xcodePullRequestURL,
@@ -121,5 +130,9 @@ extension EnvironmentValues {
       number: buildNumber,
       message: message
     )
+
+    logger?.debug("Successfully found Xcode Cloud RunEnvironment")
+
+    return runEnvironment
   }
 }

--- a/Sources/Core/Models/Environment/EnvironmentValues+RunEnvironments.swift
+++ b/Sources/Core/Models/Environment/EnvironmentValues+RunEnvironments.swift
@@ -26,7 +26,7 @@ extension EnvironmentValues {
     )
 
     logger?.debug("\(runEnvironment)")
-    
+
     return runEnvironment
   }
 

--- a/Sources/Core/Models/Environment/EnvironmentValues.swift
+++ b/Sources/Core/Models/Environment/EnvironmentValues.swift
@@ -69,7 +69,7 @@ struct EnvironmentValues {
 extension EnvironmentValues {
   var isAnalyticsEnabled: Bool { self.bool(for: "BUILDKITE_ANALYTICS_ENABLED") ?? true }
   var analyticsToken: String? { self.string(for: "BUILDKITE_ANALYTICS_TOKEN", private: true) }
-  var analyticsBaseUrl: URL? { self.url(for: "BUILDKITE_ANALYTICS_BASE_URL") }
+  var analyticsBaseURL: URL? { self.url(for: "BUILDKITE_ANALYTICS_BASE_URL") }
 
   var isAnalyticsDebugEnabled: Bool { self.bool(for: "BUILDKITE_ANALYTICS_DEBUG_ENABLED") ?? false }
 

--- a/Sources/Core/Models/Environment/EnvironmentValues.swift
+++ b/Sources/Core/Models/Environment/EnvironmentValues.swift
@@ -123,7 +123,7 @@ private func getInfoDictionaryValue(key: String) -> String? {
 }
 
 extension String {
-  /// Trims whitespace from both ends of a string, if the resulting string is empty, returns `nil`
+  /// Trims whitespace from both ends of a string, if the resulting string is empty, returns `nil`.
   fileprivate func trimmed() -> String? {
     let result = self.trimmingCharacters(in: .whitespacesAndNewlines)
     return result.isEmpty ? nil : result

--- a/Sources/Core/TestCollector.swift
+++ b/Sources/Core/TestCollector.swift
@@ -23,7 +23,8 @@ public struct TestCollector {
 
     let uploader: UploadClient?
     if let apiToken = environment.analyticsToken, apiToken != "" {
-      let api = ApiClient.live(apiToken: apiToken)
+      let baseUrl = environment.analyticsBaseUrl ?? URL(string: Self.baseURL)!
+      let api = ApiClient.live(apiToken: apiToken, baseUrl: baseUrl)
       let runEnvironment = environment.runEnvironment()
       uploader = .live(api: api, runEnvironment: runEnvironment, logger: logger)
     } else {
@@ -63,6 +64,7 @@ public struct TestCollector {
 
   public private(set) static var shared: TestCollector?
 
+  public static let baseURL = "https://analytics-api.buildkite.com/v1/"
   static let name = "test-collector-swift"
   static let version = "0.3.0"
 }

--- a/Sources/Core/TestCollector.swift
+++ b/Sources/Core/TestCollector.swift
@@ -22,7 +22,7 @@ public struct TestCollector {
     let tracer = Tracer.live()
 
     let uploader: UploadClient?
-    if let apiToken = environment.analyticsToken, apiToken != "" {
+    if let apiToken = environment.analyticsToken {
       let baseUrl = environment.analyticsBaseUrl ?? URL(string: Self.baseURL)!
       let api = ApiClient.live(apiToken: apiToken, baseUrl: baseUrl)
       let runEnvironment = environment.runEnvironment()

--- a/Sources/Core/TestCollector.swift
+++ b/Sources/Core/TestCollector.swift
@@ -23,8 +23,8 @@ public struct TestCollector {
 
     let uploader: UploadClient?
     if let apiToken = environment.analyticsToken {
-      let baseUrl = environment.analyticsBaseUrl ?? URL(string: Self.baseURL)!
-      let api = ApiClient.live(apiToken: apiToken, baseUrl: baseUrl)
+      let baseURL = environment.analyticsBaseURL ?? URL(string: Self.baseURL)!
+      let api = ApiClient.live(apiToken: apiToken, baseURL: baseURL)
       let runEnvironment = environment.runEnvironment()
       uploader = .live(api: api, runEnvironment: runEnvironment, logger: logger)
     } else {

--- a/Sources/Core/Util/AnyCodable.swift
+++ b/Sources/Core/Util/AnyCodable.swift
@@ -11,7 +11,7 @@ struct AnyCodable {
     self.base = base
   }
 
-  /// Used for converting arrays and dictionaries
+  /// Used for converting arrays and dictionaries.
   fileprivate init(_ base: Any) {
     self.base = base
   }

--- a/Sources/Core/Util/AnyCodable.swift
+++ b/Sources/Core/Util/AnyCodable.swift
@@ -1,0 +1,113 @@
+///  A type-erased codable value.
+struct AnyCodable {
+  var base: Any
+
+  /// Creates a type-erased codable value that wraps the given instance.
+  ///
+  /// - Parameter base: A codable value to wrap.
+  init(_ base: Codable) {
+    self.base = base
+  }
+
+  /// Used for converting arrays and dictionaries
+  fileprivate init(_ base: Any) {
+    self.base = base
+  }
+}
+
+extension AnyCodable: Decodable {
+  init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+
+    if let value = try? container.decode(Bool.self) {
+      self.init(value)
+    } else if let value = try? container.decode(Int.self) {
+      self.init(value)
+    } else if let value = try? container.decode(Double.self) {
+      self.init(value)
+    } else if let value = try? container.decode(String.self) {
+      self.init(value)
+    } else if let value = try? container.decode([AnyCodable].self) {
+      self.init(value.map(\.base))
+    } else if let value = try? container.decode([String: AnyCodable].self) {
+      self.init(value.mapValues(\.base))
+    } else {
+      throw DecodingError.typeMismatch(
+        AnyCodable.self,
+        .init(
+          codingPath: container.codingPath,
+          debugDescription: "Unable to decode value"
+        )
+      )
+    }
+  }
+}
+
+extension AnyCodable: Encodable {
+  func encode(to encoder: Encoder) throws {
+    switch self.base {
+    case let value as [Any]:
+      try value.map(AnyCodable.init).encode(to: encoder)
+    case let value as [String: Any]:
+      try value.mapValues(AnyCodable.init).encode(to: encoder)
+    case let value as Encodable:
+      try value.encode(to: encoder)
+    default:
+      throw EncodingError.invalidValue(
+        self.base,
+        .init(
+          codingPath: encoder.codingPath,
+          debugDescription: "Unable to encode value \(self.base)"
+        )
+      )
+    }
+  }
+}
+
+extension AnyCodable: CustomStringConvertible {
+  var description: String {
+    String(describing: self.base)
+  }
+}
+
+extension AnyCodable: Equatable {
+  static func == (lhs: AnyCodable, rhs: AnyCodable) -> Bool {
+    isEqual(lhs.base, rhs.base)
+  }
+}
+
+extension AnyCodable: ExpressibleByBooleanLiteral {
+  init(booleanLiteral value: Bool) {
+    self.init(value)
+  }
+}
+
+extension AnyCodable: ExpressibleByIntegerLiteral {
+  init(integerLiteral value: IntegerLiteralType) {
+    self.init(value)
+  }
+}
+
+extension AnyCodable: ExpressibleByFloatLiteral {
+  init(floatLiteral value: FloatLiteralType) {
+    self.init(value)
+  }
+}
+
+extension AnyCodable: ExpressibleByStringLiteral {
+  init(stringLiteral value: String) {
+    self.init(value)
+  }
+}
+
+extension AnyCodable: ExpressibleByArrayLiteral {
+  init(arrayLiteral elements: AnyCodable...) {
+    self.init(elements.map(\.base))
+  }
+}
+
+extension AnyCodable: ExpressibleByDictionaryLiteral {
+  init(dictionaryLiteral elements: (String, AnyCodable)...) {
+    self.init(Dictionary(elements) { $1 }.mapValues(\.base))
+  }
+}

--- a/Sources/Core/Util/AnyCodable.swift
+++ b/Sources/Core/Util/AnyCodable.swift
@@ -73,7 +73,7 @@ extension AnyCodable: Encodable {
 
 extension AnyCodable: CustomStringConvertible {
   var description: String {
-    if self.base is Void { return "nil" }
+    if self.base is NSNull { return "nil" }
     return String(describing: self.base)
   }
 }

--- a/Sources/Core/Util/IsEqual.swift
+++ b/Sources/Core/Util/IsEqual.swift
@@ -1,0 +1,42 @@
+/// Returns a Boolean value indicating whether two values are equal.
+///
+/// - Parameters:
+///   - lhs: A value to compare.
+///   - rhs: Another value to compare.
+func isEqual(_ lhs: Any, _ rhs: Any) -> Bool {
+  func open<T>(_: T.Type) -> ((Any, Any) -> Bool)? {
+    (Witness<T>.self as? AnyEquatable.Type)?.isEqual
+  }
+
+  if let isEqual = _openExistential(type(of: lhs), do: open) {
+    // lhs is equatable
+    return isEqual(lhs, rhs)
+  } else if
+    let lhs = lhs as? [Any],
+    let rhs = rhs as? [Any]
+  {
+    // Arrays that are not equatable or have been type-erased
+    return lhs.elementsEqual(rhs, by: isEqual)
+  } else if
+    let lhs = lhs as? [AnyHashable: Any],
+    let rhs = rhs as? [AnyHashable: Any],
+    lhs.count == rhs.count
+  {
+    // Dictionaries that are not equatable or have been type-erased
+    return lhs.allSatisfy { isEqual($1, rhs[$0] as Any) }
+  } else {
+    return false
+  }
+}
+
+private enum Witness<T> {}
+
+private protocol AnyEquatable {
+  static func isEqual(_ lhs: Any, _ rhs: Any) -> Bool
+}
+
+extension Witness: AnyEquatable where T: Equatable {
+  fileprivate static func isEqual(_ lhs: Any, _ rhs: Any) -> Bool {
+    lhs as? T == rhs as? T
+  }
+}

--- a/Tests/CoreTests/AnyCodableTests.swift
+++ b/Tests/CoreTests/AnyCodableTests.swift
@@ -15,7 +15,8 @@ class AnyCodableTests: XCTestCase {
       "dictionary": {
         "0": "foo",
         "1": "bar"
-      }
+      },
+      "nil": null
     }
     """#.data(using: .utf8)!
 
@@ -27,6 +28,7 @@ class AnyCodableTests: XCTestCase {
     XCTAssertEqual(output["string"]?.base as? String, "Blob")
     XCTAssertEqual(output["array"]?.base as? [String], ["A", "B", "C"])
     XCTAssertEqual(output["dictionary"]?.base as? [String: String], ["0": "foo", "1": "bar"])
+    XCTAssertEqual(output["nil"]?.base as? NSNull, NSNull())
 
     XCTAssertEqual(
       output,
@@ -37,6 +39,7 @@ class AnyCodableTests: XCTestCase {
         "string": "Blob",
         "array": ["A", "B", "C"],
         "dictionary": ["0": "foo", "1": "bar"],
+        "nil": nil,
       ]
     )
   }
@@ -51,6 +54,7 @@ class AnyCodableTests: XCTestCase {
       "string": "Blob",
       "array": ["A", "B", "C"],
       "dictionary": ["0": "foo", "1": "bar"],
+      "nil": nil,
     ]
 
     let data = try encoder.encode(input)
@@ -65,6 +69,7 @@ class AnyCodableTests: XCTestCase {
         "string": "Blob",
         "array": ["A", "B", "C"],
         "dictionary": ["0": "foo", "1": "bar"],
+        "nil": NSNull(),
       ]
     )
   }

--- a/Tests/CoreTests/AnyCodableTests.swift
+++ b/Tests/CoreTests/AnyCodableTests.swift
@@ -1,0 +1,71 @@
+@testable import Core
+import XCTest
+
+class AnyCodableTests: XCTestCase {
+  func testDecoding() throws {
+    let decoder = JSONDecoder()
+
+    let input = #"""
+    {
+      "bool": true,
+      "int": 7,
+      "double": 42.42,
+      "string": "Blob",
+      "array": ["A", "B", "C"],
+      "dictionary": {
+        "0": "foo",
+        "1": "bar"
+      }
+    }
+    """#.data(using: .utf8)!
+
+    let output = try decoder.decode([String: AnyCodable].self, from: input)
+
+    XCTAssertEqual(output["bool"]?.base as? Bool, true)
+    XCTAssertEqual(output["int"]?.base as? Int, 7)
+    XCTAssertEqual(output["double"]?.base as? Double, 42.42)
+    XCTAssertEqual(output["string"]?.base as? String, "Blob")
+    XCTAssertEqual(output["array"]?.base as? [String], ["A", "B", "C"])
+    XCTAssertEqual(output["dictionary"]?.base as? [String: String], ["0": "foo", "1": "bar"])
+
+    XCTAssertEqual(
+      output,
+      [
+        "bool": true,
+        "int": 7,
+        "double": 42.42,
+        "string": "Blob",
+        "array": ["A", "B", "C"],
+        "dictionary": ["0": "foo", "1": "bar"],
+      ]
+    )
+  }
+
+  func testEncoding() throws {
+    let encoder = JSONEncoder()
+
+    let input: [String: AnyCodable] = [
+      "bool": true,
+      "int": 7,
+      "double": 42.42,
+      "string": "Blob",
+      "array": ["A", "B", "C"],
+      "dictionary": ["0": "foo", "1": "bar"],
+    ]
+
+    let data = try encoder.encode(input)
+    let output = try JSONSerialization.jsonObject(with: data, options: [])
+
+    XCTAssertEqual(
+      output as? NSDictionary,
+      [
+        "bool": true,
+        "int": 7,
+        "double": 42.42,
+        "string": "Blob",
+        "array": ["A", "B", "C"],
+        "dictionary": ["0": "foo", "1": "bar"],
+      ]
+    )
+  }
+}

--- a/Tests/CoreTests/ApiClientTests.swift
+++ b/Tests/CoreTests/ApiClientTests.swift
@@ -15,7 +15,7 @@ final class ApiClientTests: XCTestCase {
     }
     let api = ApiClient.live(
       apiToken: "token",
-      baseUrl: URL(string: "http://api.test.com/")!,
+      baseURL: URL(string: "http://api.test.com/")!,
       session: session
     )
     let results = TestResults.json(runEnv: .init(key: "key"), data: [])

--- a/Tests/CoreTests/ApiClientTests.swift
+++ b/Tests/CoreTests/ApiClientTests.swift
@@ -30,7 +30,7 @@ final class ApiClientTests: XCTestCase {
     XCTAssertEqual(request.httpMethod, "POST")
     XCTAssertEqual(
       request.httpBodyDictionary,
-      ["format": "json", "run_env": ["key": "key"], "data": []]
+      ["format": "json", "run_env": ["key": "key"], "data": NSArray()]
     )
   }
 }

--- a/Tests/CoreTests/ApiClientTests.swift
+++ b/Tests/CoreTests/ApiClientTests.swift
@@ -13,7 +13,11 @@ final class ApiClientTests: XCTestCase {
       requests.append(request)
       return ("{\"status\":\"OK\"}".data(using: .utf8)!, .stub())
     }
-    let api = ApiClient.live(apiToken: "token", session: session)
+    let api = ApiClient.live(
+      apiToken: "token",
+      baseUrl: URL(string: "http://api.test.com/")!,
+      session: session
+    )
     let results = TestResults.json(runEnv: .init(key: "key"), data: [])
 
     let (value, _) = try await api.data(for: .upload(results), as: Response.self)
@@ -21,7 +25,7 @@ final class ApiClientTests: XCTestCase {
     XCTAssertEqual(value.status, "OK")
     XCTAssertEqual(requests.count, 1)
     let request = try XCTUnwrap(requests.first)
-    XCTAssertEqual(request.url?.absoluteString, "https://analytics-api.buildkite.com/v1/uploads")
+    XCTAssertEqual(request.url?.absoluteString, "http://api.test.com/uploads")
     XCTAssertEqual(request.authorizationHeader, "Token token=\"token\"")
     XCTAssertEqual(request.httpMethod, "POST")
     XCTAssertEqual(

--- a/Tests/CoreTests/EnvironmentValuesTests.swift
+++ b/Tests/CoreTests/EnvironmentValuesTests.swift
@@ -16,4 +16,36 @@ final class EnvironmentValuesTests: XCTestCase {
     XCTAssertEqual(environment.string(for: "TWO"), "ENVIRONMENT")
     XCTAssertEqual(environment.string(for: "THREE"), "INFO PLIST")
   }
+
+  func testTrimsValues() {
+    let values = ["ONE": "ONE   "]
+    let processEnvironment = ["TWO": "   TWO   "]
+    let infoPlist = ["THREE": "   THREE"]
+    let environment = EnvironmentValues(
+      values: values,
+      getFromEnvironment: { processEnvironment[$0] },
+      getFromInfoDictionary: { infoPlist[$0] }
+    )
+    XCTAssertEqual(environment.string(for: "ONE"), "ONE")
+    XCTAssertEqual(environment.string(for: "TWO"), "TWO")
+    XCTAssertEqual(environment.string(for: "THREE"), "THREE")
+  }
+
+  func testIgnoresEmptyValues() {
+    let values = ["NOTHING": ""]
+    let processEnvironment = ["NOTHING": "       "]
+    let infoPlist = ["NOTHING": "   \n   "]
+    let environment = EnvironmentValues(
+      values: values,
+      getFromEnvironment: { processEnvironment[$0] },
+      getFromInfoDictionary: { infoPlist[$0] }
+    )
+    XCTAssertEqual(environment.string(for: "NOTHING"), nil)
+  }
+
+  func testURL() {
+    let processEnvironment = ["TEST_URL": "https://api.test.com/"]
+    let environment = EnvironmentValues(getFromEnvironment: { processEnvironment[$0] })
+    XCTAssertEqual(environment.url(for: "TEST_URL"), URL(string: "https://api.test.com/")!)
+  }
 }

--- a/Tests/CoreTests/RunEnvironmentTests.swift
+++ b/Tests/CoreTests/RunEnvironmentTests.swift
@@ -12,7 +12,8 @@ final class RunEnvironmentTests: XCTestCase {
         "BUILDKITE_BUILD_NUMBER": "buildNumber",
         "BUILDKITE_JOB_ID": "jobId",
         "BUILDKITE_MESSAGE": "message",
-      ]
+      ],
+      getFromEnvironment: { _ in nil }
     )
 
     XCTAssertEqual(
@@ -40,7 +41,8 @@ final class RunEnvironmentTests: XCTestCase {
         "CIRCLE_BUILD_URL": "buildUrl",
         "CIRCLE_BRANCH": "main",
         "CIRCLE_SHA1": "commitSha",
-      ]
+      ],
+      getFromEnvironment: { _ in nil }
     )
     XCTAssertEqual(
       environmentValues.runEnvironment(),
@@ -70,7 +72,8 @@ final class RunEnvironmentTests: XCTestCase {
         "GITHUB_SHA": "commitSha",
         "GITHUB_WORKFLOW": "workflowName",
         "GITHUB_ACTOR": "username",
-      ]
+      ],
+      getFromEnvironment: { _ in nil }
     )
 
     XCTAssertEqual(
@@ -98,7 +101,8 @@ final class RunEnvironmentTests: XCTestCase {
         "CI_WORKFLOW": "workflowName",
         "CI_BRANCH": "main",
         "CI_PULL_REQUEST_HTML_URL": "pullRequestUrl",
-      ]
+      ],
+      getFromEnvironment: { _ in nil }
     )
 
     XCTAssertEqual(

--- a/Tests/CoreTests/RunEnvironmentTests.swift
+++ b/Tests/CoreTests/RunEnvironmentTests.swift
@@ -135,7 +135,11 @@ final class RunEnvironmentTests: XCTestCase {
       executionNamePrefix: "executionNamePrefix",
       executionNameSuffix: "executionNameSuffix",
       version: "version",
-      collector: "collector"
+      collector: "collector",
+      customEnvironment: [
+        "custom_key": "customKey",
+        "tags": ["A", "B", "C"],
+      ]
     )
 
     let data = try JSONEncoder().encode(runEnvironment)
@@ -158,7 +162,24 @@ final class RunEnvironmentTests: XCTestCase {
         "execution_name_suffix": "executionNameSuffix",
         "version": "version",
         "collector": "collector",
+        "custom_key": "customKey",
+        "tags": ["A", "B", "C"],
       ]
     )
+  }
+
+  func testCustomEnvironmentTakesPrecedence() throws {
+    let runEnvironment = RunEnvironment(
+      key: "key",
+      customEnvironment: [
+        "key": "customKey",
+      ]
+    )
+
+    let data = try JSONEncoder().encode(runEnvironment)
+
+    let json = try JSONSerialization.jsonObject(with: data)
+
+    XCTAssertEqual(json as? NSDictionary, ["key": "customKey"])
   }
 }

--- a/Tests/CoreTests/RunEnvironmentTests.swift
+++ b/Tests/CoreTests/RunEnvironmentTests.swift
@@ -62,7 +62,7 @@ final class RunEnvironmentTests: XCTestCase {
     let environmentValues = EnvironmentValues(
       values: [
         "GITHUB_ACTION": "action",
-        "GITHUB_REF": "main",
+        "GITHUB_REF_NAME": "main",
         "GITHUB_RUN_NUMBER": "runNumber",
         "GITHUB_RUN_ATTEMPT": "runAttempt",
         "GITHUB_REPOSITORY": "repository",

--- a/Tests/CoreTests/RunEnvironmentTests.swift
+++ b/Tests/CoreTests/RunEnvironmentTests.swift
@@ -12,8 +12,7 @@ final class RunEnvironmentTests: XCTestCase {
         "BUILDKITE_BUILD_NUMBER": "buildNumber",
         "BUILDKITE_JOB_ID": "jobId",
         "BUILDKITE_MESSAGE": "message",
-      ],
-      getFromEnvironment: { _ in nil }
+      ]
     )
 
     XCTAssertEqual(
@@ -41,8 +40,7 @@ final class RunEnvironmentTests: XCTestCase {
         "CIRCLE_BUILD_URL": "buildUrl",
         "CIRCLE_BRANCH": "main",
         "CIRCLE_SHA1": "commitSha",
-      ],
-      getFromEnvironment: { _ in nil }
+      ]
     )
     XCTAssertEqual(
       environmentValues.runEnvironment(),
@@ -64,7 +62,7 @@ final class RunEnvironmentTests: XCTestCase {
     let environmentValues = EnvironmentValues(
       values: [
         "GITHUB_ACTION": "action",
-        "GITHUB_REF_NAME": "main",
+        "GITHUB_REF": "main",
         "GITHUB_RUN_NUMBER": "runNumber",
         "GITHUB_RUN_ATTEMPT": "runAttempt",
         "GITHUB_REPOSITORY": "repository",
@@ -72,8 +70,7 @@ final class RunEnvironmentTests: XCTestCase {
         "GITHUB_SHA": "commitSha",
         "GITHUB_WORKFLOW": "workflowName",
         "GITHUB_ACTOR": "username",
-      ],
-      getFromEnvironment: { _ in nil }
+      ]
     )
 
     XCTAssertEqual(
@@ -101,8 +98,7 @@ final class RunEnvironmentTests: XCTestCase {
         "CI_WORKFLOW": "workflowName",
         "CI_BRANCH": "main",
         "CI_PULL_REQUEST_HTML_URL": "pullRequestUrl",
-      ],
-      getFromEnvironment: { _ in nil }
+      ]
     )
 
     XCTAssertEqual(

--- a/Tests/CoreTests/TestResultsTests.swift
+++ b/Tests/CoreTests/TestResultsTests.swift
@@ -84,9 +84,13 @@ final class TestResultsTests: XCTestCase {
             "scope": "TestResultsTests",
             "name": "testSuccess",
             "result": "passed",
-            "failure_expanded": [],
-            "history": ["section": "span0", "detail": [:], "children": []],
-          ],
+            "failure_expanded": NSArray(),
+            "history": [
+              "section": "span0",
+              "detail": NSDictionary(),
+              "children": NSArray(),
+            ] as NSDictionary,
+          ] as NSDictionary,
           [
             "id": "00000000-0000-0000-0000-000000000001",
             "scope": "TestResultsTests",
@@ -105,7 +109,11 @@ final class TestResultsTests: XCTestCase {
                 ],
               ],
             ],
-            "history": ["section": "span1", "detail": [:], "children": []],
+            "history": [
+              "section": "span1",
+              "detail": NSDictionary(),
+              "children": NSArray(),
+            ] as NSDictionary,
           ],
           [
             "id": "00000000-0000-0000-0000-000000000002",
@@ -114,11 +122,15 @@ final class TestResultsTests: XCTestCase {
             "result": "failed",
             "failure_reason": "3 failures: First failure, Second failure, Third failure",
             "failure_expanded": [
-              ["backtrace": [], "expanded": ["Failure 1"]],
-              ["backtrace": [], "expanded": ["Failure 2"]],
-              ["backtrace": [], "expanded": ["Failure 3"]],
+              ["backtrace": NSArray(), "expanded": ["Failure 1"]],
+              ["backtrace": NSArray(), "expanded": ["Failure 2"]],
+              ["backtrace": NSArray(), "expanded": ["Failure 3"]],
             ],
-            "history": ["section": "span2", "detail": [:], "children": []],
+            "history": [
+              "section": "span2",
+              "detail": NSDictionary(),
+              "children": NSArray(),
+            ] as NSDictionary,
           ],
         ],
       ]

--- a/Tests/CoreTests/TestResultsTests.swift
+++ b/Tests/CoreTests/TestResultsTests.swift
@@ -79,18 +79,22 @@ final class TestResultsTests: XCTestCase {
         "format": "json",
         "run_env": ["key": "test"],
         "data": [
-          [
-            "id": "00000000-0000-0000-0000-000000000000",
-            "scope": "TestResultsTests",
-            "name": "testSuccess",
-            "result": "passed",
-            "failure_expanded": NSArray(),
-            "history": [
-              "section": "span0",
-              "detail": NSDictionary(),
-              "children": NSArray(),
-            ] as NSDictionary,
-          ] as NSDictionary,
+          NSDictionary(
+            dictionary: [
+              "id": "00000000-0000-0000-0000-000000000000",
+              "scope": "TestResultsTests",
+              "name": "testSuccess",
+              "result": "passed",
+              "failure_expanded": NSArray(),
+              "history": NSDictionary(
+                dictionary: [
+                  "section": "span0",
+                  "detail": NSDictionary(),
+                  "children": NSArray(),
+                ]
+              ),
+            ]
+          ),
           [
             "id": "00000000-0000-0000-0000-000000000001",
             "scope": "TestResultsTests",
@@ -109,11 +113,13 @@ final class TestResultsTests: XCTestCase {
                 ],
               ],
             ],
-            "history": [
-              "section": "span1",
-              "detail": NSDictionary(),
-              "children": NSArray(),
-            ] as NSDictionary,
+            "history": NSDictionary(
+              dictionary: [
+                "section": "span1",
+                "detail": NSDictionary(),
+                "children": NSArray(),
+              ]
+            ),
           ],
           [
             "id": "00000000-0000-0000-0000-000000000002",
@@ -126,11 +132,13 @@ final class TestResultsTests: XCTestCase {
               ["backtrace": NSArray(), "expanded": ["Failure 2"]],
               ["backtrace": NSArray(), "expanded": ["Failure 3"]],
             ],
-            "history": [
-              "section": "span2",
-              "detail": NSDictionary(),
-              "children": NSArray(),
-            ] as NSDictionary,
+            "history": NSDictionary(
+              dictionary: [
+                "section": "span2",
+                "detail": NSDictionary(),
+                "children": NSArray(),
+              ]
+            ),
           ],
         ],
       ]


### PR DESCRIPTION
## 💬 Summary of Changes

- Add `public static var baseURL: String` to `TestCollector` resolves #36
- Add `customEnvironment: [String: AnyCodable]?` to `RunEnvironment` 
- Add `BUILDKITE_ANALYTICS_ENVIRONMENT` and `BUILDKITE_ANALYTICS_BASE_URL` to `EnvironmentValues`
- Minor documentation changes
- Improved test coverage 

## 🧾 Checklist

<!-- Actions you should have taken before opening this pull request. -->

- [x] 🧐 Performed a self-review of the changes
- [x] ✅ Added tests to cover changes
- [x] 🏎 Ran Unit Tests and they all passed
- [x] 🏷 Labeled this PR appropriately 


## 📝 Items of Note

- These are mostly dev related changes. `BUILDKITE_ANALYTICS_ENVIRONMENT` can be used for testing out beta features and `BUILDKITE_ANALYTICS_BASE_URL` can be used for integration testing.