### PR TITLE
CI: queue=macos

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -6,7 +6,7 @@ steps:
     branches:
       - "*"
     agents:
-      os: "macos"
+      queue: macos
     env:
       DEVELOPER_DIR: "/Applications/Xcode_{{matrix.xcode_version}}.app/Contents/Developer"
     matrix:
@@ -22,7 +22,7 @@ steps:
     branches:
       - "*"
     agents:
-      os: "macos"
+      queue: macos
     env:
       DEVELOPER_DIR: "/Applications/Xcode_{{matrix.xcode_version}}.app/Contents/Developer"
     matrix:


### PR DESCRIPTION
Use `macos` queue for CI builds.
This matches a minor internal change to our CI infrastructure.