### PR TITLE
Handle updated Upload API response, more permissive, better errors

### DIFF
--- a/Sources/Core/ApiClient/ApiClient.swift
+++ b/Sources/Core/ApiClient/ApiClient.swift
@@ -6,25 +6,25 @@ import FoundationNetworking
 
 struct ApiClient {
   let decoder: JSONDecoder
-  var request: (ApiRoute) async throws -> (Data, URLResponse)
+  var request: (ApiRoute) async throws -> (Data, HTTPURLResponse)
 
   init(
     decoder: JSONDecoder = JSONDecoder(),
-    request: @escaping (ApiRoute) async throws -> (Data, URLResponse)
+    request: @escaping (ApiRoute) async throws -> (Data, HTTPURLResponse)
   ) {
     self.request = request
     self.decoder = decoder
   }
 
-  func data(for route: ApiRoute) async throws -> (value: Data, response: URLResponse) {
+  func data(for route: ApiRoute) async throws -> (value: Data, response: HTTPURLResponse) {
     try await self.request(route)
   }
 
   func data<Value: Decodable>(
     for route: ApiRoute,
     as type: Value.Type
-  ) async throws -> (value: Value, response: URLResponse) {
-    let (data, response) = try await self.request(route)
+  ) async throws -> (value: Value, response: HTTPURLResponse) {
+    let (data, response) = try await self.data(for: route)
     let value = try decode(data, as: type)
     return (value, response)
   }

--- a/Sources/Core/ApiClient/ApiSession.swift
+++ b/Sources/Core/ApiClient/ApiSession.swift
@@ -5,9 +5,9 @@ import FoundationNetworking
 #endif
 
 struct ApiSession {
-  var data: (URLRequest) async throws -> (Data, URLResponse)
+  var data: (URLRequest) async throws -> (Data, HTTPURLResponse)
 
-  func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+  func data(for request: URLRequest) async throws -> (Data, HTTPURLResponse) {
     try await self.data(request)
   }
 }
@@ -17,7 +17,11 @@ extension ApiSession {
     ApiSession { request in
       #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
       if #available(macOS 12, iOS 15, tvOS 15, watchOS 8, *) {
-        return try await session.data(for: request)
+        let (data, response) = try await session.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+          throw URLError(.unsupportedURL)
+        }
+        return (data, httpResponse)
       }
       #endif
 
@@ -29,7 +33,7 @@ extension ApiSession {
           try await withCheckedThrowingContinuation { continuation in
             dataTask = session.dataTask(with: request) { data, response, error in
               if let data, let response {
-                continuation.resume(returning: (data, response))
+                continuation.resume(returning: (data, response as! HTTPURLResponse))
               } else {
                 continuation.resume(throwing: error ?? URLError(.badServerResponse))
               }

--- a/Sources/Core/Models/Api/UploadResponse.swift
+++ b/Sources/Core/Models/Api/UploadResponse.swift
@@ -1,30 +1,18 @@
 import Foundation
 
-/// A type returned by the analytics api after uploading test results.
+/// Response from Test Engine API after uploading test results.
 struct UploadResponse: Equatable {
-  /// The uploads identifier.
-  var id: String
+  /// The UUID allocated to this upload
+  var uploadID: String?
 
-  /// The identifier for test run associated to the upload.
-  var runId: String
-
-  /// The number of individual test results that are queued for processing.
-  var queued: Int
-
-  /// The number of test results that were uploaded but will not be processed.
-  var skipped: Int
-
-  /// Any errors that occurred
-  var errors: [String]
+  /// The URL that can be used to view upload details
+  var uploadURL: String?
 }
 
 extension UploadResponse: Decodable {
   enum CodingKeys: String, CodingKey {
-    case id
-    case runId = "run_id"
-    case queued
-    case skipped
-    case errors
+    case uploadID = "upload_id"
+    case uploadURL = "upload_url"
   }
 }
 

--- a/Sources/Core/UploadClient/UploadClient.swift
+++ b/Sources/Core/UploadClient/UploadClient.swift
@@ -2,18 +2,6 @@ import Foundation
 
 /// A type used to upload traces asynchronously during a test run.
 struct UploadClient {
-  enum UploadError: LocalizedError {
-    case error(message: String)
-    case unknown
-
-    var errorDescription: String? {
-      switch self {
-      case let .error(message): return message
-      case .unknown: return "Unknown Error"
-      }
-    }
-  }
-
   private var record: (Trace) -> Void
   private var waitForUploads: (TimeInterval) -> Void
 

--- a/Tests/CoreTests/TestHelpers/ApiClient.swift
+++ b/Tests/CoreTests/TestHelpers/ApiClient.swift
@@ -16,8 +16,8 @@ extension ApiClient {
   }
 }
 
-extension URLResponse {
-  static func stub(from url: URL = URL(string: "test")!) -> URLResponse {
-    URLResponse(url: url, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
+extension HTTPURLResponse {
+  static func stub(from url: URL = URL(string: "test")!, status: Int = 200) -> HTTPURLResponse {
+    HTTPURLResponse(url: url, statusCode: status, httpVersion: "1.1", headerFields: nil)!
   }
 }


### PR DESCRIPTION
The response body of the upload API is undocumented and not a public/stable API. This collector was treating all existing fields as mandatory during JSON decoding. An overhaul of the ingestion system in 2024 removed some fields from the response which are no longer relevant or synchronously available, which resulted in unclear errors from this Swift collector.

This patch:
- updates the response parsing to accept the new values from the response (`upload_id`, `upload_url`),
- is more permissive about future changes (handle these fields no longer existing),
- produces more specific & helpful error / warning / debug regarding upload response, including the HTTP response status.
  - this required some refactoring to use `HTTPURLResponse` instead of `URLResponse` throughout.

I've tested this, with and without `BUILDKITE_ANALYTICS_DEBUG_ENABLED=true`, by pointing the included `Examples/DemoLibrary` test suite at a local Test Engine endpoint, and seen it handle various error and success conditions (bad status code, with and without a server-side error message, invalid JSON response, JSON response without expected keys, etc).

I haven't _added_ test coverage, but I have verified that the existing tests are passing, and fixed the one that failed due to the newer more detailed error message.

Caveat: I'm not experienced with Swift, there's quite likely better ways to do some of this.

## 🧾 Checklist

- [x] 🧐 Performed a self-review of the changes
- [x] ✅ Added tests to cover changes
- [x] 🏎 Ran Unit Tests and they all passed
- [x] 🏷 Labeled this PR appropriately 