### PR TITLE
CI: macOS 15 (was 13), newer Swift & Xcode

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -12,17 +12,17 @@ on:
 jobs:
   macos-tests:
     name: Swift ${{ matrix.swift-version }} (macOS)
-    runs-on: macos-13
+    runs-on: macos-15
     strategy:
       matrix:
         xcode-version:
-          - '14.1'
-          - '15.2'
+          - '15.4'
+          - '16.2'
         include:
-          - swift-version: '5.7.1'
-            xcode-version: '14.1'
-          - swift-version: '5.9.2'
-            xcode-version: '15.2'
+          - swift-version: '5.10'
+            xcode-version: '15.4'
+          - swift-version: '6.0.3'
+            xcode-version: '16.2'
     env:
       DEVELOPER_DIR: "/Applications/Xcode_${{ matrix.xcode-version }}.app/Contents/Developer"
     steps:


### PR DESCRIPTION
Target newer macOS / Xcode / Swift in CI.

Related:

- https://xcodereleases.com/?scope=release
- https://github.com/actions/runner-images/blob/main/images/macos/macos-15-arm64-Readme.md
- https://github.com/actions/runner-images/blob/main/README.md