### PR TITLE
Docs: use “Test Engine” not “Analytics” where possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Buildkite Test Collector for Swift (Beta)
 
-Official [Buildkite Test Analytics](https://buildkite.com/test-analytics) collector for Swift test frameworks ✨
+Official [Buildkite Test Engine](https://buildkite.com/platform/test-engine/) collector for Swift test frameworks ✨
 
 ⚒ **Supported test frameworks:** XCTest, Quick, and Nimble.
 
@@ -106,12 +106,12 @@ Key: CI_PULL_REQUEST_HTML_URL, Value: $(CI_PULL_REQUEST_HTML_URL)
 The same key value pairs can be specified in your main bundle's `info.plist` file if you would rather specify them there. Note variables in the environment take precedent over those in the `info.plist` file.
 ### Step 4
 
-Push your changes to a branch, and open a pull request. After a test run has been triggered, results will start appearing in your analytics dashboard.
+Push your changes to a branch, and open a pull request. After a test run has been triggered, results will start appearing in your Test Engine dashboard.
 
 ```bash
-git checkout -b add-buildkite-test-analytics
-git commit -am "Add Buildkite Test Analytics"
-git push origin add-buildkite-test-analytics
+git checkout -b add-buildkite-test-engine
+git commit -am "Add Buildkite Test Engine"
+git push origin add-buildkite-test-engine
 ```
 
 ## 🔍 Debugging

--- a/Sources/BuildkiteTestCollector/TestCollector.swift
+++ b/Sources/BuildkiteTestCollector/TestCollector.swift
@@ -1,7 +1,7 @@
 import Core
 
 public enum TestCollector {
-  /// The base URL for the Test Analytics API.
+  /// The base URL for the Buildkite Test Engine API.
   public static var baseURL: String {
     Core.TestCollector.baseURL
   }

--- a/Sources/Core/Models/Api/ApiRoute.swift
+++ b/Sources/Core/Models/Api/ApiRoute.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Different endpoints for the Buildkite analytics service
+/// Different endpoints for Buildkite Test Engine
 ///
 /// Currently there is only a single upload endpoint, in the future this could be expanded to include others though. The new route would be handled in
 /// `ApiClient`'s `makeRequest` function

--- a/Sources/Core/Models/Api/TestResults.swift
+++ b/Sources/Core/Models/Api/TestResults.swift
@@ -1,21 +1,22 @@
 /// A type containing a test run's metadata and test results.
 ///
-/// This is the type expected by the analytics api.
+/// This is the type expected by the Test Engine upload API.
 struct TestResults: Equatable {
   /// The format for the included data
   var format: String
 
-  /// Information used to identify the test run. Test results with matching run environments will be grouped together by the analytics api.
+  /// Information used to identify the test run.
+  /// Test results with matching run_env[key] will be grouped into a single run by Test Engine
   var runEnv: RunEnvironment
 
-  /// An array of traces
+  /// An array of test executions
   var data: [Trace]
 
   /// Constructs test results compatible with the JSON API
   ///
   /// - Parameters:
   ///   - runEnv: The run environment for when the data was captured.
-  ///   - data: An array of traces.
+  ///   - data: An array of test executions.
   /// - Returns: Test results compatible with the JSON API
   static func json(runEnv: RunEnvironment, data: [Trace]) -> TestResults {
     TestResults(format: "json", runEnv: runEnv, data: data)


### PR DESCRIPTION
This doesn't change anything functional e.g. environment variable names, just documentation and code comments.